### PR TITLE
feat: Remove required attribute from placeholder input field

### DIFF
--- a/src/app/(admin)/admin/users/_components/Modal.tsx
+++ b/src/app/(admin)/admin/users/_components/Modal.tsx
@@ -73,7 +73,6 @@ export default function Modal({
           label="Kelas"
           name="kelas"
           placeholder="Kelas"
-          required
         />
         <TextField
           type="password"


### PR DESCRIPTION
The required attribute was removed from the placeholder input field in the Modal component. This change allows the user to leave the field empty if necessary.